### PR TITLE
Quote values and replace hyphens with underscores

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,14 +42,14 @@ func asKV(params []*ssm.Parameter, prefix string) string {
 		name := *param.Name
 		value := *param.Value
 
-		builder.WriteString(fmt.Sprintf("%s=%s\n", clean(name, prefix), value))
+		builder.WriteString(fmt.Sprintf("%s=\"%s\"\n", clean(name, prefix), value))
 	}
 
 	return builder.String()
 }
 
 func clean(s, prefix string) string {
-	r := strings.NewReplacer(prefix+"/", "", ".", "_", "/", "_")
+	r := strings.NewReplacer(prefix+"/", "", ".", "_", "/", "_", "-", "_")
 	return r.Replace(s)
 }
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 	prefix := flag.String("prefix", "", "Parameter store prefix")
 	flag.Parse()
 	if *prefix == "" {
-		exit("Error: required flag 'prefix' missing.")
+		exitWithError("Error: required flag 'prefix' missing.")
 	}
 
 	sess := session.Must(session.NewSession())
@@ -29,7 +29,7 @@ func main() {
 
 	output, err := client.GetParametersByPath(input)
 	if err != nil {
-		exit(fmt.Sprintf("Error: unable to retrieve from parameter store - %s.", err.Error()))
+		exitWithError(fmt.Sprintf("Error: unable to retrieve from parameter store - %s.", err.Error()))
 	}
 
 	fmt.Print(asKV(output.Parameters, *prefix))
@@ -53,7 +53,7 @@ func clean(s, prefix string) string {
 	return r.Replace(s)
 }
 
-func exit(msg string) {
-	fmt.Println(msg)
+func exitWithError(msg string) {
+	fmt.Fprintf(os.Stderr, msg)
 	os.Exit(1)
 }

--- a/main.go
+++ b/main.go
@@ -42,13 +42,18 @@ func asKV(params []*ssm.Parameter, prefix string) string {
 		name := *param.Name
 		value := *param.Value
 
-		builder.WriteString(fmt.Sprintf("%s=\"%s\"\n", clean(name, prefix), value))
+		builder.WriteString(fmt.Sprintf("%s='%s'\n", cleanPrefix(name, prefix), cleanValue(value)))
 	}
 
 	return builder.String()
 }
 
-func clean(s, prefix string) string {
+func cleanValue(s string) string {
+	r := strings.NewReplacer("'", "\\'")
+	return r.Replace(s)
+}
+
+func cleanPrefix(s, prefix string) string {
 	r := strings.NewReplacer(prefix+"/", "", ".", "_", "/", "_", "-", "_")
 	return r.Replace(s)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ssm"
+)
+
+func TestAsKV(t *testing.T) {
+	// Prefixed name
+	name1 := "foo/name"
+	value1 := "value"
+
+	// Period, slash, hyphen replacement
+	name2 := "name.baz/bar-bat"
+	value2 := "value"
+
+	// Value escaping single quote, to prevent injection attack
+	name3 := "name"
+	value3 := "value' \" ${hax}"
+
+	param1 := ssm.Parameter{Name: &name1, Value: &value1}
+	param2 := ssm.Parameter{Name: &name2, Value: &value2}
+	param3 := ssm.Parameter{Name: &name3, Value: &value3}
+
+	params := []*ssm.Parameter{
+		&param1,
+		&param2,
+		&param3,
+	}
+
+	paramString := asKV(params, "foo")
+
+	expectedString := 
+		"name='value'\n" + 
+		"name_baz_bar_bat='value'\n" +
+		"name='value\\' \" ${hax}'\n"
+		
+	if paramString != expectedString {
+		t.Error("Failed: " + paramString + " does not match " + expectedString)
+	}
+}


### PR DESCRIPTION
## What does this change?

This change outputs the values of params quoted and replaces hyphens with underscores to provide output slightly more consumable on the command line.

e.g.

```
foo-bar=bat's are great
```

Will be output as:

```
foo_bar='bat's are great'
```