### PR TITLE
ci: remove snyk cron

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,11 +1,7 @@
-# This action runs every day at 6 AM and on every push
-# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
 # Otherwise it will run snyk test
 name: Snyk
 
 on:
-  schedule:
-    - cron: '0 6 * * *'
   push:
     branches:
       - main

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,4 +1,3 @@
-# Otherwise it will run snyk test
 name: Snyk
 
 on:


### PR DESCRIPTION
## What does this change?

Running snyk at 6am every day makes zero difference vs just running it on push to main, and may actively cause problems, especially around charges for extra minutes. I've removed this schedule