### PR TITLE
ci: fix snyk workflow

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,5 +13,6 @@ jobs:
       DEBUG: true
       ORG: guardian-devtools
       SKIP_NODE: true
+      SKIP_GO: false
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -10,7 +10,6 @@ jobs:
   security:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
-      DEBUG: true
       ORG: guardian-devtools
       SKIP_NODE: true
       SKIP_SBT: true

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,6 +13,7 @@ jobs:
       DEBUG: true
       ORG: guardian-devtools
       SKIP_NODE: true
+      SKIP_SBT: true
       SKIP_GO: false
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What does this change?

The snyk workflow had not run for 5 or 6 months. On running it again for the first time, it failed. This PR makes some small changes to fix it, and skips sbt to simplify the action.

NB there seems to be a recurring problem with the debug option that needs further investigation (also occurs in this [PR](https://github.com/guardian/grid/pull/4023/files))

## How to test

Run workflow against branch

## How can we measure success?

Snyk workflow passes, nest-secrets shows up on snyk

<img width="646" alt="An image showing a successful run of the Snyk GitHub action" src="https://user-images.githubusercontent.com/67543397/214510977-3a594b3c-75a7-401c-8875-2b59aac41f69.png">
